### PR TITLE
[CT-025] Adiciona/melhora endpoint de cadastro do usuário

### DIFF
--- a/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/AuthenticationService.kt
@@ -2,6 +2,7 @@ package com.cashtrack.cashtrack_api.application.service
 
 import com.cashtrack.cashtrack_api.domain.auth.request.AuthenticationRequest
 import com.cashtrack.cashtrack_api.domain.auth.response.AuthenticationResponse
+import com.cashtrack.cashtrack_api.domain.error.exception.DatabaseRegisterNotFoundException
 import com.cashtrack.cashtrack_api.domain.repository.UserRepository
 import com.cashtrack.cashtrack_api.port.config.property.JwtProperties
 import org.springframework.security.authentication.AuthenticationManager
@@ -31,7 +32,13 @@ class AuthenticationService(
         )
         return AuthenticationResponse(
             accessToken = accessToken,
-            userId = usersRepository.findByEmail(user.username).get().id
+            userId = usersRepository.findByEmail(user.username)
+                .orElseThrow {
+                    DatabaseRegisterNotFoundException(
+                        message = "User does not exist for this e-mail."
+                    )
+                }
+                .id
         )
     }
 }

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/AuthenticationService.kt
@@ -31,7 +31,7 @@ class AuthenticationService(
         )
         return AuthenticationResponse(
             accessToken = accessToken,
-            userId = usersRepository.findByEmail(user.username)?.id
+            userId = usersRepository.findByEmail(user.username).get().id
         )
     }
 }

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/CustomUserDetailsService.kt
@@ -14,8 +14,7 @@ class CustomUserDetailsService(
     private val usersRepository:UserRepository,
 ): UserDetailsService {
     override fun loadUserByUsername(username:String): UserDetails =
-        usersRepository.findByEmail(username)?.mapToUserDetails()
-            ?: throw RuntimeException("User not found!")
+        usersRepository.findByEmail(username).get().mapToUserDetails()
 
     private fun ApplicationUser.mapToUserDetails(): UserDetails =
         User.builder()

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/CustomUserDetailsService.kt
@@ -1,11 +1,13 @@
 package com.cashtrack.cashtrack_api.application.service
 
 import com.cashtrack.cashtrack_api.domain.UserCashtrack
+import com.cashtrack.cashtrack_api.domain.error.exception.DatabaseRegisterNotFoundException
 import com.cashtrack.cashtrack_api.domain.repository.UserRepository
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Service
+import kotlin.jvm.optionals.getOrNull
 
 typealias ApplicationUser = UserCashtrack
 
@@ -14,7 +16,13 @@ class CustomUserDetailsService(
     private val usersRepository:UserRepository,
 ): UserDetailsService {
     override fun loadUserByUsername(username:String): UserDetails =
-        usersRepository.findByEmail(username).get().mapToUserDetails()
+        usersRepository.findByEmail(username)
+            .orElseThrow {
+                DatabaseRegisterNotFoundException(
+                    message = "User does not exist for this e-mail."
+                )
+            }
+            .mapToUserDetails()
 
     private fun ApplicationUser.mapToUserDetails(): UserDetails =
         User.builder()

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/UserService.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/UserService.kt
@@ -14,10 +14,12 @@ class UserService(
     private val usersRepository: UserRepository,
     private val mapper: UserAdapter,
 ) {
-    @Caching(evict = [CacheEvict("UsersList", allEntries = true), CacheEvict("UserDetails", allEntries = true)])
     fun registerNewUser(newUser: UserRegisterRequest): UserResponse {
         val new = mapper.mapEntry(newUser)
-        if (usersRepository.findByEmail(new.email) == null) {
+
+        val userExists = usersRepository.findByEmail(new.email).isPresent
+
+        if (!userExists) {
             usersRepository.save(new)
             return mapper.mapView(new)
         } else throw UserAlreadyExistsException(

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/auth/request/UserRegisterRequest.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/auth/request/UserRegisterRequest.kt
@@ -15,5 +15,6 @@ data class UserRegisterRequest(
     val username:String,
     @field:NotEmpty(message = "Password must no be empty.")
     @field:NotBlank(message = "Password must no be blank.")
+    @field:Size(min = 8, max = 100, message = "Password size must be at least 8 characters long")
     val password:String
 )

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/auth/request/UserRegisterRequest.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/auth/request/UserRegisterRequest.kt
@@ -1,5 +1,6 @@
 package com.cashtrack.cashtrack_api.domain.auth.request
 
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
@@ -8,6 +9,7 @@ data class UserRegisterRequest(
     @field:NotEmpty(message = "Email must not be empty.")
     @field:NotBlank(message = "Email must not be blank.")
     @field:Size(min = 5, max = 100, message = "Email size must be between 5 and 100 characters.")
+    @field:Email(message = "Invalid email format.")
     val email:String,
     @field:NotEmpty(message = "Username must not be empty.")
     @field:NotBlank(message = "Username must not be blank.")

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/error/GlobalExceptionHandler.kt
@@ -37,11 +37,13 @@ class GlobalExceptionHandler {
             exception,
         )
 
-        val messages = exception.bindingResult.fieldErrors.mapNotNull { it.defaultMessage }
+        val errorMessage = exception.bindingResult.fieldErrors
+            .firstNotNullOfOrNull { it.defaultMessage }
+            ?: ExceptionEnum.BAD_ARGUMENTS.message
 
         return ErrorResponse(
             code = ExceptionEnum.BAD_ARGUMENTS.name,
-            message = messages.first(),
+            message = errorMessage,
             description = null
         )
     }

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/error/GlobalExceptionHandler.kt
@@ -36,9 +36,13 @@ class GlobalExceptionHandler {
             "Erro ao validar campo(s) da requisicao",
             exception,
         )
+
+        val messages = exception.bindingResult.fieldErrors.mapNotNull { it.defaultMessage }
+
         return ErrorResponse(
-            ExceptionEnum.BAD_ARGUMENTS.name,
-            ExceptionEnum.BAD_ARGUMENTS.message,
+            code = ExceptionEnum.BAD_ARGUMENTS.name,
+            message = messages.first(),
+            description = null
         )
     }
 

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/error/enum/ExceptionEnum.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/error/enum/ExceptionEnum.kt
@@ -22,5 +22,10 @@ enum class ExceptionEnum(
         code = "UNKNOWN_ERROR",
         message = "Ocorreu um erro desconhecido.",
         httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    DATABASE_REGISTER_NOT_FOUND(
+        code = "DATABASE_REGISTER_NOT_FOUND",
+        message = "Registro não encontrado no banco",
+        httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
     )
 }

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/error/exception/DatabaseRegisterNotFoundException.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/error/exception/DatabaseRegisterNotFoundException.kt
@@ -1,0 +1,10 @@
+package com.cashtrack.cashtrack_api.domain.error.exception
+
+import com.cashtrack.cashtrack_api.domain.error.enum.ExceptionEnum
+
+open class DatabaseRegisterNotFoundException(
+    override val errorEnum: ExceptionEnum = ExceptionEnum.DATABASE_REGISTER_NOT_FOUND,
+    val data: String? = null,
+    override val code: String = errorEnum.code,
+    override val message: String = "Registro não encontrado $data",
+) : CustomException(errorEnum)

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/repository/UserRepository.kt
@@ -2,8 +2,9 @@ package com.cashtrack.cashtrack_api.domain.repository
 
 import com.cashtrack.cashtrack_api.domain.UserCashtrack
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
 
 interface UserRepository: JpaRepository<UserCashtrack, Long> {
     // Query is auto implemented by JPA Repository
-    fun findByEmail(username:String?): UserCashtrack?
+    fun findByEmail(username:String?): Optional<UserCashtrack>
 }


### PR DESCRIPTION
## Porque esse PR foi criado? 🤔
Esse _pull-request_ adiciona melhorias necessárias para o endpoint de cadastro de usuários que já existia no projeto, as melhorias foram adicionadas para se adaptar a todos os critérios de aceite da task dentro da versão v0.0.3 

## O que foi feito? 🧰
Os seguintes critérios de aceite ainda precisavam ser concluídos para a tarefa:

> 1. A senha deve ter no mínimo 8 caracteres, contendo letras e números;
> 2. Caso o e-mail já exista, o sistema deve exibir uma mensagem de erro;
> 3. O sistema deve validar todos os dados de entrada e retornar mensagens de erro claras em caso de dados inválidos;

- Features
  - O retorno de erro agora mapeia corretamente o campos nos quais ocorreram erros 
- Bugfixes
  - Foram adicionadas novas annotations `@field` nos campos que ainda precisavam ter verificações

![image](https://github.com/user-attachments/assets/dcd6e2be-87a4-417f-9cb8-1ac77e9b6d8d)

## ✅ Como validar esse PR?
- Faça checkout para a branch do PR -> `git checkout CT-025-users-register`
- Rode o banco de dados local com as variáveis de ambiente configuradas -> `docker compose up -d --force-recreate --build db`
- Execute a aplicação com a task do gradle -> `gradle bootRun`
- Execute uma request para `POST /users`
  - Verifique se todas as validações de campo estão implementadas
  - Valide se é possível registrar um usuário
    - Tenha certeza que o retorno é o objeto esperado com `id` e `username` 