### PR TITLE
[HOTFIX] Corrige bug adicionando @Component em classe adapter

### DIFF
--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/adapter/ExpenseAdapter.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/adapter/ExpenseAdapter.kt
@@ -3,7 +3,9 @@ package com.cashtrack.cashtrack_api.domain.adapter
 import com.cashtrack.cashtrack_api.domain.Expense
 import com.cashtrack.cashtrack_api.domain.dto.request.ExpenseRegisterRequest
 import com.cashtrack.cashtrack_api.domain.dto.response.ExpenseResponse
+import org.springframework.stereotype.Component
 
+@Component
 class ExpenseAdapter : Adapter<Expense, ExpenseResponse, ExpenseRegisterRequest> {
     override fun mapEntry(e: ExpenseRegisterRequest):Expense {
         return Expense(


### PR DESCRIPTION
## Porque esse PR foi criado? 🤔
Esse PR é uma hotfix para corrigir um erro na build da aplicação em uma das últimas alterações, ao subir as alterações recentes do PR https://github.com/P-py/cash-track-api/pull/9 foram encontrados erros no build por falta de uma annotation do spring.

![image](https://github.com/user-attachments/assets/76e78aaa-7d2c-4bab-b564-5032628312d3)


## O que foi feito? 🧰
Foi adicionada a annotation na classe para corrigir o processo de build e reparar o ambinte de produção no railway.

- Bugfixes
  - A alteração adiciona a anotação `@Component` à classe `ExpenseAdapter` para torná-la um componente Spring.

## ✅ Como validar esse PR?
- Faça checkout para a branch do PR -> `git checkout fix-bean-dependency`
- Rode o banco de dados local com as variáveis de ambiente configuradas -> `docker compose up -d --force-recreate --build db`
- Execute a aplicação com a task do gradle -> `gradle bootRun`
  - Certifique que nenhum erro ocorre no momento em que a aplicação está sendo construída
 
## ⚠️ Observações
- Precisamos priorizar o merge desse PR para concertar o ambiente da nossa aplicação que **_está fora do ar_**