### PR TITLE
[CT-050] Corrige erro de SignatureException no filtro de autenticação

### DIFF
--- a/src/main/kotlin/com/cashtrack/cashtrack_api/port/config/bean/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/port/config/bean/JwtAuthenticationFilter.kt
@@ -2,9 +2,13 @@ package com.cashtrack.cashtrack_api.port.config.bean
 
 import com.cashtrack.cashtrack_api.application.service.CustomUserDetailsService
 import com.cashtrack.cashtrack_api.application.service.TokenService
+import com.cashtrack.cashtrack_api.domain.error.exception.ErrorResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.security.SignatureException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetails
@@ -17,26 +21,45 @@ class JwtAuthenticationFilter(
     private val userDetailsService:CustomUserDetailsService,
     private val tokenService:TokenService,
 ): OncePerRequestFilter(){
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
     ){
-        val authHeader:String? = request.getHeader("Authorization")
-        if (authHeader.doesNotContainBearerToken()){
-            filterChain.doFilter(request, response)
-            return
-        }
-        val jwtToken = authHeader!!.extractTokenValue()
-        val email = tokenService.extractEmail(jwtToken)
-        if (email != null && SecurityContextHolder.getContext().authentication == null){
-            val foundUser = userDetailsService.loadUserByUsername(email)
-            if (tokenService.isValid(jwtToken, foundUser)){
-                updateContext(foundUser, request)
+        try {
+            val authHeader:String? = request.getHeader("Authorization")
+            if (authHeader.doesNotContainBearerToken()){
+                filterChain.doFilter(request, response)
+                return
             }
-            filterChain.doFilter(request, response)
+            val jwtToken = authHeader!!.extractTokenValue()
+            val email = tokenService.extractEmail(jwtToken)
+            if (email != null && SecurityContextHolder.getContext().authentication == null){
+                val foundUser = userDetailsService.loadUserByUsername(email)
+                if (tokenService.isValid(jwtToken, foundUser)){
+                    updateContext(foundUser, request)
+                }
+                filterChain.doFilter(request, response)
+            }
+        } catch (ex: SignatureException) {
+            buildUnauthorizedResponse(
+                response,
+                "INVALID_TOKEN",
+                "Token inválido",
+                "A assinatura do token JWT é inválida."
+            )
+        } catch (ex: Exception) {
+            buildUnauthorizedResponse(
+                response,
+                "UNKNOWN_ERROR",
+                "Erro desconhecido",
+                "Ocorreu um erro na autenticação do token."
+            )
         }
     }
+
     private  fun updateContext(foundUser: UserDetails, request: HttpServletRequest){
         val authToken = UsernamePasswordAuthenticationToken(foundUser, null, foundUser.authorities)
         authToken.details = WebAuthenticationDetailsSource().buildDetails(request)
@@ -45,6 +68,22 @@ class JwtAuthenticationFilter(
 
     private fun String?.doesNotContainBearerToken():Boolean =
         this == null || !this.startsWith("Bearer ")
+
     private fun String.extractTokenValue():String =
         this.substringAfter("Bearer ")
+
+
+    private fun buildUnauthorizedResponse(
+        response: HttpServletResponse,
+        code: String,
+        message: String,
+        description: String
+    ) {
+        val errorResponse = ErrorResponse(code, message, description)
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = "application/json"
+        response.characterEncoding = "UTF-8"
+        val mapper = ObjectMapper()
+        response.writer.write(mapper.writeValueAsString(errorResponse))
+    }
 }


### PR DESCRIPTION
## Porque esse PR foi criado? 🤔
Esse PR aprimora a classe `JwtAuthenticationFilter` para melhorar o tratamento de erros e a geração de respostas na API `Cashtrack`. As principais alterações incluem a adição de um tratamento de exceção específico para `SignatureException`, a criação de um método para gerar respostas não autorizadas e a importação das classes necessárias para essas funcionalidades.

As alterações aqui também visam melhorar a experiência do usuário deixando os erros mais claros, além de corrigir vulnerabilidades evitando que stacktraces fiquem expostos.


## O que foi feito? 🧰
- [ ] Features
- [X] Bugfixes
  * Importações adicionadas para `ErrorResponse`, `ObjectMapper`, `SignatureException` e `HttpStatus` para oferecer suporte à nova funcionalidade de tratamento de erros.
  * Introduzido um bloco `try-catch` no método `doFilterInternal` para tratar `SignatureException` e exceções gerais, fornecendo respostas de erro específicas para cada uma.
  * Criado um método `buildUnauthorizedResponse` para gerar uma resposta não autorizada estruturada com um código de erro, mensagem e descrição.
- [ ] Configurações no ambiente (desenvolvimento ou produção)
- [ ] Testes unitários

![image](https://github.com/user-attachments/assets/542c92e6-1e62-4e19-9093-f24f62d1d144)

## ✅ Como validar esse PR?
- Faça checkout para a branch do PR -> `git checkout CT-030-add-dashboard-endpoints`
- Rode o banco de dados local com as variáveis de ambiente configuradas -> `docker compose up -d --force-recreate --build db`
- Execute a aplicação com a task do gradle -> `gradle bootRun`
- Execute uma resquest para qualquer endpoint no qual seja necessário o token de autenticação (qualquer endpoint do dashboard)
  - Use um token inválido na request
  - Certifique-se de que o erro retornado para um token inválido está no formato esperado
  - Certifique-se de que em nenhum cenário de erro no filtro de autenticação os dados da aplicação ficam expostos 