### PR TITLE
[CT-040] Altera envio do token de acesso do body para um header

### DIFF
--- a/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/AuthenticationService.kt
@@ -1,9 +1,6 @@
 package com.cashtrack.cashtrack_api.application.service
 
 import com.cashtrack.cashtrack_api.domain.auth.request.AuthenticationRequest
-import com.cashtrack.cashtrack_api.domain.auth.response.AuthenticationResponse
-import com.cashtrack.cashtrack_api.domain.error.exception.DatabaseRegisterNotFoundException
-import com.cashtrack.cashtrack_api.domain.repository.UserRepository
 import com.cashtrack.cashtrack_api.port.config.property.JwtProperties
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -16,9 +13,8 @@ class AuthenticationService(
     private val userDetailsService:CustomUserDetailsService,
     private val tokenService:TokenService,
     private val jwtProperties:JwtProperties,
-    private val usersRepository: UserRepository,
 ){
-    fun authentication(authRequest:AuthenticationRequest): AuthenticationResponse {
+    fun authentication(authRequest: AuthenticationRequest): String {
         authManager.authenticate(
             UsernamePasswordAuthenticationToken(
                 authRequest.email,
@@ -30,15 +26,6 @@ class AuthenticationService(
             userDetails = user,
             expirationDate = Date(System.currentTimeMillis() + jwtProperties.accessTokenExpiration)
         )
-        return AuthenticationResponse(
-            accessToken = accessToken,
-            userId = usersRepository.findByEmail(user.username)
-                .orElseThrow {
-                    DatabaseRegisterNotFoundException(
-                        message = "User does not exist for this e-mail."
-                    )
-                }
-                .id
-        )
+        return accessToken
     }
 }

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/port/config/bean/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/port/config/bean/SecurityConfiguration.kt
@@ -87,7 +87,7 @@ class SecurityConfiguration(
 
         val configuration = CorsConfiguration()
         configuration.addAllowedHeader("*")
-        configuration.addExposedHeader("Cookie")
+        configuration.addExposedHeader("Authorization")
         configuration.allowedOriginPatterns = allowedOrigins
         configuration.allowedMethods = allowedMethods
         configuration.allowCredentials = true

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/port/controller/AuthController.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/port/controller/AuthController.kt
@@ -2,7 +2,9 @@ package com.cashtrack.cashtrack_api.port.controller
 
 import com.cashtrack.cashtrack_api.application.service.AuthenticationService
 import com.cashtrack.cashtrack_api.domain.auth.request.AuthenticationRequest
-import com.cashtrack.cashtrack_api.domain.auth.response.AuthenticationResponse
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -12,8 +14,13 @@ class AuthController(
     private val authenticationService:AuthenticationService,
 ){
     @PostMapping
-    fun authenticate(@RequestBody authRequest: AuthenticationRequest): AuthenticationResponse {
+    fun authenticate(
+        @RequestBody authRequest: AuthenticationRequest,
+        response: HttpServletResponse,
+    ): ResponseEntity<Unit> {
         val authResponse = authenticationService.authentication(authRequest)
-        return authResponse
+        response.setHeader(HttpHeaders.AUTHORIZATION, authResponse)
+
+        return ResponseEntity.noContent().build()
     }
 }


### PR DESCRIPTION
## Porque esse PR foi criado? 🤔
Esse PR inclui diversas alterações no fluxo de autenticação e na configuração de segurança do projeto `cashtrack_api`. As alterações mais importantes envolvem a modificação do `AuthenticationService` para retornar uma string de token em vez de um objeto `AuthenticationResponse`, a atualização do `AuthController` para definir o cabeçalho de autorização na resposta e a alteração dos cabeçalhos expostos em `SecurityConfiguration`.

## O que foi feito? 🧰
### Alterações no Fluxo de Autenticação:
* O método `authentication` foi alterado para retornar uma string de token em vez de um objeto `AuthenticationResponse`. Importações não utilizadas e a dependência `usersRepository` foram removidas.
* O método `authenticate` foi modificado para definir o cabeçalho de autorização em `HttpServletResponse` e ​​retornar uma `ResponseEntity<Unit>` em vez de uma `AuthenticationResponse`. Importações necessárias adicionadas para `HttpServletResponse`, `HttpHeaders` e `ResponseEntity` foram adicionadas.

### Alterações na Configuração de Segurança:
* O cabeçalho exposto de "Cookie" foi alterado para "Authorization" na configuração do CORS.

![image](https://github.com/user-attachments/assets/a4e1b72e-26b0-4a55-8d8a-f49513bca3a7)

## ✅ Como validar esse PR?
- Faça checkout para a branch do PR -> `git checkout CT-040-add-auth-header`
- Rode o banco de dados local com as variáveis de ambiente configuradas -> `docker compose up -d --force-recreate --build db`
- Execute a aplicação com a task do gradle -> `gradle bootRun`
- Execute a request de autenticação para `POST /auth`
  - Garanta que o token de acesso não é retornado no body mais, mas sim em um header de authorization

## ⚠️ Observações
- Esse PR não corrige algumas falhas de segurança referente à falta de cookies do tipo `HttpOnly`, essa correção será feita no futuro
