### PR TITLE
[CT-031] Adiciona endpoint de histórico de registros

### DIFF
--- a/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/ExpenseService.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/ExpenseService.kt
@@ -96,7 +96,7 @@ class ExpenseService(
         try {
             val update = expenseRepository.getReferenceById(updatedExpense.id)
             if (update.userCashtrack!!.id == userId) {
-                update.expenseLabel = updatedExpense.expenseLabel
+                update.label = updatedExpense.expenseLabel
                 update.value = updatedExpense.value
                 update.type = updatedExpense.type
                 update.lastUpdatedAt = LocalDateTime.now()

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/IncomeService.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/application/service/IncomeService.kt
@@ -95,7 +95,7 @@ class IncomeService(
         try {
             val update = incomeRepository.getReferenceById(updatedIncome.id)
             if (update.userCashtrack?.id == userId){
-                update.incomeLabel = updatedIncome.incomeLabel
+                update.label = updatedIncome.incomeLabel
                 update.value = updatedIncome.value
                 update.type = updatedIncome.type
                 update.lastUpdatedAt = LocalDateTime.now()

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/Expense.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/Expense.kt
@@ -7,13 +7,14 @@ import java.time.LocalDateTime
 @Entity
 data class Expense(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null,
-    var expenseLabel: String = "",
-    var value: Double = 0.0,
+    override var id: Long? = null,
+    override var label: String = "",
+    override var value: Double = 0.0,
     @Enumerated(value = EnumType.STRING)
     var type: ExpenseType = ExpenseType.INVESTMENTS,
-    val dateCreated: LocalDateTime = LocalDateTime.now(),
+    override val dateCreated: LocalDateTime = LocalDateTime.now(),
     @ManyToOne
-    var userCashtrack: UserCashtrack? = null,
-    var lastUpdatedAt: LocalDateTime? = null
-)
+    override var userCashtrack: UserCashtrack? = null,
+    override var lastUpdatedAt: LocalDateTime? = null,
+    override val source: String = "expense"
+) : Trackable

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/Income.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/Income.kt
@@ -7,13 +7,14 @@ import java.time.LocalDateTime
 @Entity
 data class Income(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null,
-    var incomeLabel: String = "",
-    var value: Double = 0.0,
+    override var id: Long? = null,
+    override var label: String = "",
+    override var value: Double = 0.0,
     @Enumerated(value = EnumType.STRING)
     var type: IncomeType = IncomeType.GIFT,
-    val dateCreated: LocalDateTime = LocalDateTime.now(),
+    override val dateCreated: LocalDateTime = LocalDateTime.now(),
     @ManyToOne
-    var userCashtrack: UserCashtrack? = null,
-    var lastUpdatedAt: LocalDateTime? = null
-)
+    override var userCashtrack: UserCashtrack? = null,
+    override var lastUpdatedAt: LocalDateTime? = null,
+    override val source: String = "income"
+) : Trackable

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/Trackable.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/Trackable.kt
@@ -1,0 +1,13 @@
+package com.cashtrack.cashtrack_api.domain
+
+import java.time.LocalDateTime
+
+interface Trackable {
+    var id: Long?
+    var label: String
+    var value: Double
+    val dateCreated: LocalDateTime
+    var userCashtrack: UserCashtrack?
+    var lastUpdatedAt: LocalDateTime?
+    val source: String
+}

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/adapter/ExpenseAdapter.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/adapter/ExpenseAdapter.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 class ExpenseAdapter : Adapter<Expense, ExpenseResponse, ExpenseRegisterRequest> {
     override fun mapEntry(e: ExpenseRegisterRequest):Expense {
         return Expense(
-            expenseLabel = e.expenseLabel,
+            label = e.expenseLabel,
             value = e.value,
             type = e.type,
             userCashtrack = null
@@ -19,7 +19,7 @@ class ExpenseAdapter : Adapter<Expense, ExpenseResponse, ExpenseRegisterRequest>
     override fun mapView(c:Expense): ExpenseResponse {
         return ExpenseResponse(
             id = c.id,
-            expenseLabel = c.expenseLabel,
+            expenseLabel = c.label,
             value = c.value,
             type = c.type,
             dateCreated = c.dateCreated,

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/adapter/HistoryAdapter.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/adapter/HistoryAdapter.kt
@@ -1,0 +1,17 @@
+package com.cashtrack.cashtrack_api.domain.adapter
+
+import com.cashtrack.cashtrack_api.domain.Trackable
+import com.cashtrack.cashtrack_api.domain.dto.response.HistoryResponse
+import org.springframework.stereotype.Component
+
+@Component
+class HistoryAdapter {
+    fun mapView(c: Trackable): HistoryResponse {
+        return HistoryResponse(
+            label = c.label,
+            value = c.value,
+            dateCreated = c.dateCreated,
+            source = c.source
+        )
+    }
+}

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/adapter/IncomeAdapter.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/adapter/IncomeAdapter.kt
@@ -10,7 +10,7 @@ class IncomeAdapter : Adapter<Income, IncomeResponse, IncomeRegisterRequest> {
     override fun mapView(c:Income): IncomeResponse {
         return IncomeResponse(
             id = c.id,
-            incomeLabel = c.incomeLabel,
+            incomeLabel = c.label,
             value = c.value,
             type = c.type,
             dateCreated = c.dateCreated,
@@ -20,7 +20,7 @@ class IncomeAdapter : Adapter<Income, IncomeResponse, IncomeRegisterRequest> {
 
     override fun mapEntry(e: IncomeRegisterRequest): Income {
         return Income(
-            incomeLabel = e.incomeLabel,
+            label = e.incomeLabel,
             value = e.value,
             type = e.type,
             userCashtrack = null

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/dto/response/HistoryResponse.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/dto/response/HistoryResponse.kt
@@ -1,0 +1,10 @@
+package com.cashtrack.cashtrack_api.domain.dto.response
+
+import java.time.LocalDateTime
+
+data class HistoryResponse(
+    val label: String,
+    val dateCreated: LocalDateTime,
+    val value: Double,
+    val source: String
+)

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/repository/ExpenseRepository.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/repository/ExpenseRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param
 
 interface ExpenseRepository: JpaRepository<Expense, Long> {
     @Query(
-        value = "SELECT * FROM expense WHERE expense_label = :label",
+        value = "SELECT * FROM expense WHERE label = :label",
         nativeQuery = true
     )
     fun getByLabel(@Param("label") label:String): List<Expense>

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/repository/IncomeRepository.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/repository/IncomeRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param
 
 interface IncomeRepository: JpaRepository<Income, Long> {
     @Query(
-        value = "SELECT * FROM income WHERE income_label = :label",
+        value = "SELECT * FROM income WHERE label = :label",
         nativeQuery = true
     )
     fun getByLabel(@Param("label") label:String): List<Income>

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/domain/repository/UserRepository.kt
@@ -1,10 +1,33 @@
 package com.cashtrack.cashtrack_api.domain.repository
 
+import com.cashtrack.cashtrack_api.domain.Trackable
 import com.cashtrack.cashtrack_api.domain.UserCashtrack
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.Optional
 
 interface UserRepository: JpaRepository<UserCashtrack, Long> {
     // Query is auto implemented by JPA Repository
     fun findByEmail(username:String?): Optional<UserCashtrack>
+
+    @Query(
+        value = """
+            SELECT 'income' AS source, label, value, type, date_created, user_cashtrack_id, last_updated_at
+            FROM income
+            WHERE user_cashtrack_id = :userId
+            
+            UNION ALL
+            
+            SELECT 'expense' AS source, label, value, type, date_created, user_cashtrack_id, last_updated_at
+            FROM expense
+            WHERE user_cashtrack_id = :userId
+            
+            order by last_updated_at desc
+            
+            limit 30;
+        """,
+        nativeQuery = true
+    )
+    fun findHistory(@Param("userId") userId: Long): List<Trackable?>
 }

--- a/src/main/kotlin/com/cashtrack/cashtrack_api/port/controller/UserController.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/port/controller/UserController.kt
@@ -4,6 +4,7 @@ import com.cashtrack.cashtrack_api.application.service.UserService
 import com.cashtrack.cashtrack_api.domain.dto.request.UserRegisterRequest
 import com.cashtrack.cashtrack_api.domain.dto.request.UserUpdateRequest
 import com.cashtrack.cashtrack_api.domain.dto.response.BalanceResponse
+import com.cashtrack.cashtrack_api.domain.dto.response.HistoryResponse
 import com.cashtrack.cashtrack_api.domain.dto.response.UserResponse
 import jakarta.transaction.Transactional
 import jakarta.validation.Valid
@@ -43,6 +44,14 @@ class UserController(
         @RequestHeader(value = "Authorization") accessToken:String
     ): ResponseEntity<BalanceResponse> {
         val userBalance = service.getBalance(accessToken)
+        return ResponseEntity.ok(userBalance)
+    }
+
+    @GetMapping("/history")
+    fun getSpendingHistory(
+        @RequestHeader(value = "Authorization") accessToken:String
+    ): ResponseEntity<List<HistoryResponse?>> {
+        val userBalance = service.getSpendingHistory(accessToken)
         return ResponseEntity.ok(userBalance)
     }
 

--- a/src/main/resources/db/migration/V6__update_labels.sql
+++ b/src/main/resources/db/migration/V6__update_labels.sql
@@ -1,0 +1,3 @@
+ALTER TABLE income RENAME COLUMN income_label TO label;
+
+ALTER TABLE expense RENAME COLUMN expense_label TO label;

--- a/src/main/resources/db/migration/V7__create_user_id_indexes.sql
+++ b/src/main/resources/db/migration/V7__create_user_id_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_user_cashtrack_id_income ON income(user_cashtrack_id);
+CREATE INDEX idx_user_cashtrack_id_expense ON expense(user_cashtrack_id);


### PR DESCRIPTION
## Porque esse PR foi criado? 🤔
Esse PR foi criado para padronizar o modelo de dados, unificar campos comuns entre as entidades `Expense` e `Income`, além de adicionar uma nova funcionalidade para recuperação do histórico de registros (gastos e entradas) do usuário.

## O que foi feito? 🧰
Principais mudanças:

### Padronização do Modelo de Dados:
- Introdução da interface `Trackable`, unificando campos comuns (`id`, `label`, `value`, etc.) entre `Expense` e `Income`.
- Atualização das entidades `Expense` e `Income` para implementar `Trackable`.
- Renomeação dos campos `expenseLabel` e `incomeLabel` para `label`.

### Atualizações no Schema do Banco de Dados:
- Renomeação das colunas `income_label` e `expense_label` para `label` nas respectivas tabelas.
- Criação de índices em `user_cashtrack_id` para melhorar a performance das queries.

### Nova Funcionalidade de Histórico de Gastos:
- Criação do `HistoryAdapter` para mapear entidades `Trackable` para `HistoryResponse`.
- Implementação do método `getSpendingHistory` em `UserService`.
- Novo endpoint `/users/history` adicionado em `UserController`.

### Atualizações de API e Repositórios:
- Ajustes no `IncomeRepository` e `ExpenseRepository` para refletirem o novo campo `label`.
- Inclusão de query customizada em `UserRepository` para obter o histórico de gastos.

### Configuração de Segurança:
- Atualização do `SecurityConfiguration` para permitir acesso autenticado ao novo endpoint `/users/history`.

## ✅ Como validar esse PR?
1. Validar se a nova interface `Trackable` foi corretamente implementada em `Income` e `Expense`.
2. Verificar se o endpoint `/users/history` retorna os dados combinados corretamente.
3. Testar se os campos `label` foram atualizados corretamente no banco de dados.
4. Testar a performance das queries após a criação dos índices.

## ⚠️ Observações
- Atenção para possíveis efeitos colaterais em queries que utilizavam os campos antigos `incomeLabel` e `expenseLabel`.
- Deploy deve ser sincronizado com a execução das migrations de banco.
