### PR TITLE
[HOTFIX] Corrige problema na configuração de segurança para /users/history

### DIFF
--- a/src/main/kotlin/com/cashtrack/cashtrack_api/port/config/bean/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/cashtrack/cashtrack_api/port/config/bean/SecurityConfiguration.kt
@@ -96,6 +96,7 @@ class SecurityConfiguration(
                     .requestMatchers(
                         HttpMethod.GET,
                         "/users/account",
+                        "/users/history",
                         "/users/balance",
                         "/incomes/{id}",
                         "/incomes",


### PR DESCRIPTION
This pull request updates the `SecurityConfiguration` class to expand the list of permitted GET request endpoints.

Security configuration changes:

* [`src/main/kotlin/com/cashtrack/cashtrack_api/port/config/bean/SecurityConfiguration.kt`](diffhunk://#diff-d071d40c83170ef61b9151d4d21ab4be33ffca4dd90849a5e798fb895b662ecdR99): Added `/users/history` to the list of allowed GET request endpoints in the `requestMatchers` configuration.